### PR TITLE
Bump to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'tag'


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/